### PR TITLE
fix: `content` contains `export default {`, ZUM-66593

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,10 @@ function getClasses(content) {
     // when `onlyLocals` is off
     from = content.indexOf('exports.locals = {');
   }
+  // check v🤷‍♂️ -- the one that works
+  if (from === -1) {
+    from = content.indexOf('export default {');
+  }
 
   if (~from) {
     content = content.slice(from);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zumper/dts-isomorphic-styles-loader",
-  "version": "2.0.1-zumper.0",
+  "version": "2.0.1-zumper.1",
   "description": "webpack loader to generate typings for css modules and isomorphic-style-loader",
   "repository": {
     "type": "git",
@@ -8,7 +8,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "registry": "https://zumper-616113654770.d.codeartifact.us-east-1.amazonaws.com/npm/npm-local/"
+    "registry": "https://zumper-616113654770.d.codeartifact.us-east-1.amazonaws.com/npm/npm/"
   },
   "dependencies": {
     "loader-utils": "^1.2.0"


### PR DESCRIPTION
Locally, if you run `yarn watch:run`, it generates some `.d.ts` files for `.less` and `.scss` files

For some time, those files have been mostly empty and broken, producing annoying "errors" in the IDE, like below

This PR fixes that

| Before | After |
|--------|--------|
| <img width="838" alt="image" src="https://github.com/user-attachments/assets/5cfd7c75-1fcc-4e74-b95a-e4e88ba6f73d" /> | <img width="861" alt="image" src="https://github.com/user-attachments/assets/927a65cf-b220-4801-9623-247f175a3192" /> | 


